### PR TITLE
Changes to add web-push support reusing xep-0357

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0</version>
+        <version>4.5.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>pushnotification</artifactId>
-    <version>0.6.0-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
 
     <name>Push Notification</name>
     <description>Adds Push Notification (XEP-0357) support to Openfire.</description>
@@ -26,6 +26,43 @@
         </plugins>
     </build>
 
+    <dependencies>       
+        <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.1</version>
+        </dependency>
+        
+        <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>23.0</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/fluent-hc -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>fluent-hc</artifactId>
+            <version>4.5.3</version>
+        </dependency> 
+        
+        <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpasyncclient -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpasyncclient</artifactId>
+            <version>4.1.3</version>
+        </dependency>     
+        
+        <!-- https://mvnrepository.com/artifact/org.bitbucket.b_c/jose4j -->
+        <dependency>
+            <groupId>org.bitbucket.b_c</groupId>
+            <artifactId>jose4j</artifactId>
+            <version>0.7.0</version>
+        </dependency>        
+    </dependencies>
+    
     <repositories>
         <!-- Here, we get our dependencies, like the parent project. -->
         <repository>

--- a/rebuild.cmd
+++ b/rebuild.cmd
@@ -1,0 +1,6 @@
+call mvn clean package
+
+cd target
+rename pushnotification-openfire-plugin-assembly.jar pushnotification.jar
+copy pushnotification.jar C:\openfire_4_5_0\plugins\pushnotification.jar
+pause

--- a/src/changelog.html
+++ b/src/changelog.html
@@ -44,7 +44,12 @@
 Push Notification Plugin Changelog
 </h1>
 
-<p><b>0.6.0</b> -- (to be determined)</p>
+<p><b>0.7.0</b> -- (to be determined)</p>
+<ul>
+     <li>Added support for web push for converse.js.</li>
+</ul>
+
+<p><b>0.6.0</b> --  Jun 10, 2019</p>
 <ul>
      <li>Initial release.</li>
 </ul>

--- a/src/main/java/nl/martijndwars/webpush/ClosableCallback.java
+++ b/src/main/java/nl/martijndwars/webpush/ClosableCallback.java
@@ -1,0 +1,45 @@
+package nl.martijndwars.webpush;
+
+import java.io.IOException;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.concurrent.FutureCallback;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+
+/**
+ * Java 7's try-with-resource closes the client before the future is completed.
+ * This callback captures the client and closes it once the request is
+ * completed.
+ *
+ * See also http://stackoverflow.com/a/35962718/368220.
+ */
+public class ClosableCallback implements FutureCallback<HttpResponse> {
+    private CloseableHttpAsyncClient closeableHttpAsyncClient;
+
+    public ClosableCallback(CloseableHttpAsyncClient closeableHttpAsyncClient) {
+        this.closeableHttpAsyncClient = closeableHttpAsyncClient;
+    }
+
+    @Override
+    public void completed(HttpResponse httpResponse) {
+        close();
+    }
+
+    @Override
+    public void failed(Exception e) {
+        close();
+    }
+
+    @Override
+    public void cancelled() {
+        close();
+    }
+
+    private void close() {
+        try {
+            closeableHttpAsyncClient.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/nl/martijndwars/webpush/Encrypted.java
+++ b/src/main/java/nl/martijndwars/webpush/Encrypted.java
@@ -1,0 +1,55 @@
+package nl.martijndwars.webpush;
+
+import java.security.PublicKey;
+
+public class Encrypted {
+    private final PublicKey publicKey;
+    private final byte[] salt;
+    private final byte[] ciphertext;
+
+    public Encrypted(final PublicKey publicKey, final byte[] salt, final byte[] ciphertext) {
+        this.publicKey = publicKey;
+        this.salt = salt;
+        this.ciphertext = ciphertext;
+    }
+
+    public PublicKey getPublicKey() {
+        return publicKey;
+    }
+
+    public byte[] getSalt() {
+        return salt;
+    }
+
+    public byte[] getCiphertext() {
+        return ciphertext;
+    }
+
+    public static class Builder {
+        private PublicKey publicKey;
+        private byte[] salt;
+        private byte[] ciphertext;
+
+        public Builder withPublicKey(PublicKey publicKey) {
+            this.publicKey = publicKey;
+
+            return this;
+        }
+
+        public Builder withSalt(byte[] salt) {
+            this.salt = salt;
+
+            return this;
+        }
+
+        public Builder withCiphertext(byte[] ciphertext) {
+            this.ciphertext = ciphertext;
+
+            return this;
+        }
+
+        public Encrypted build() {
+            return new Encrypted(publicKey, salt, ciphertext);
+        }
+    }
+}

--- a/src/main/java/nl/martijndwars/webpush/HttpEce.java
+++ b/src/main/java/nl/martijndwars/webpush/HttpEce.java
@@ -1,0 +1,182 @@
+package nl.martijndwars.webpush;
+
+import org.bouncycastle.crypto.digests.SHA256Digest;
+import org.bouncycastle.crypto.generators.HKDFBytesGenerator;
+import org.bouncycastle.crypto.params.HKDFParameters;
+import org.bouncycastle.jce.interfaces.ECPublicKey;
+
+import javax.crypto.*;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.security.*;
+import java.util.Map;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * An implementation of HTTP ECE (Encrypted Content Encoding) as described in
+ * https://tools.ietf.org/html/draft-ietf-httpbis-encryption-encoding-01
+ */
+public class HttpEce {
+    private Map<String, KeyPair> keys;
+    private Map<String, String> labels;
+
+    public HttpEce(Map<String, KeyPair> keys, Map<String, String> labels) {
+        this.keys = keys;
+        this.labels = labels;
+    }
+
+    /**
+     * Future versions might require a null-terminated info string?
+     *
+     * @param type
+     * @return
+     */
+    protected static byte[] buildInfo(String type, byte[] context) {
+        ByteBuffer buffer = ByteBuffer.allocate(19 + type.length() + context.length);
+
+        buffer.put("Content-Encoding: ".getBytes(UTF_8), 0, 18);
+        buffer.put(type.getBytes(UTF_8), 0, type.length());
+        buffer.put(new byte[1], 0, 1);
+        buffer.put(context, 0, context.length);
+
+        return buffer.array();
+    }
+
+    /**
+     * Convenience method for computing the HMAC Key Derivation Function. The
+     * real work is offloaded to BouncyCastle.
+     */
+    protected static byte[] hkdfExpand(byte[] ikm, byte[] salt, byte[] info, int length) throws InvalidKeyException, NoSuchAlgorithmException {
+        HKDFBytesGenerator hkdf = new HKDFBytesGenerator(new SHA256Digest());
+        hkdf.init(new HKDFParameters(ikm, salt, info));
+
+        byte[] okm = new byte[length];
+        hkdf.generateBytes(okm, 0, length);
+
+        return okm;
+    }
+
+    public byte[][] deriveKey(byte[] salt, byte[] key, String keyId, PublicKey dh, byte[] authSecret, int padSize) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException, InvalidAlgorithmParameterException, BadPaddingException, IllegalBlockSizeException, NoSuchProviderException, IOException {
+        byte[] secret = null;
+        byte[] context = null;
+
+        if (key != null) {
+            secret = key;
+        } else if (dh != null) {
+            byte[][] bytes = deriveDH(keyId, dh);
+            secret = bytes[0];
+            context = bytes[1];
+        } else if (keyId != null) {
+            secret = keys.get(keyId).getPublic().getEncoded();
+        }
+
+        if (secret == null) {
+            throw new IllegalStateException("Unable to determine the secret");
+        }
+
+        byte[] keyinfo;
+        byte[] nonceinfo;
+
+        if (authSecret != null) {
+            secret = hkdfExpand(secret, authSecret, buildInfo("auth", new byte[0]), 32);
+        }
+
+        keyinfo = buildInfo("aesgcm", context);
+        nonceinfo = buildInfo("nonce", context);
+
+        byte[] hkdf_key = hkdfExpand(secret, salt, keyinfo, 16);
+        byte[] hkdf_nonce = hkdfExpand(secret, salt, nonceinfo, 12);
+
+        return new byte[][]{
+                hkdf_key,
+                hkdf_nonce
+        };
+    }
+
+    /**
+     * Compute the shared secret using the server's key pair (indicated by
+     * keyId) and the client's public key. Also compute context.
+     *
+     * @param keyId
+     * @param publicKey
+     * @return
+     */
+    private byte[][] deriveDH(String keyId, PublicKey publicKey) throws NoSuchProviderException, NoSuchAlgorithmException, InvalidKeyException, IOException {
+        PublicKey senderPubKey = keys.get(keyId).getPublic();
+
+        KeyAgreement keyAgreement = KeyAgreement.getInstance("ECDH");
+        keyAgreement.init(keys.get(keyId).getPrivate());
+        keyAgreement.doPhase(publicKey, true);
+
+        byte[] secret = keyAgreement.generateSecret();
+        byte[] context = concat(labels.get(keyId).getBytes(UTF_8), new byte[1], lengthPrefix(publicKey), lengthPrefix(senderPubKey));
+
+        return new byte[][]{
+                secret,
+                context
+        };
+    }
+
+    private byte[] lengthPrefix(Key key) throws IOException {
+        byte[] bytes = Utils.savePublicKey((ECPublicKey) key);
+
+        return concat(intToBytes(bytes.length), bytes);
+    }
+
+    /**
+     * Cast an integer to a two-byte array
+     */
+    private byte[] intToBytes(int x) throws IOException {
+        byte[] bytes = new byte[2];
+
+        bytes[1] = (byte) (x & 0xff);
+        bytes[0] = (byte) (x >> 8);
+
+        return bytes;
+    }
+
+    /**
+     * Utility to concat byte arrays
+     */
+    private byte[] concat(byte[]... arrays) {
+        int lastPos = 0;
+
+        byte[] combined = new byte[combinedLength(arrays)];
+
+        for (byte[] array : arrays) {
+            System.arraycopy(array, 0, combined, lastPos, array.length);
+
+            lastPos += array.length;
+        }
+
+        return combined;
+    }
+
+    /**
+     * Compute combined array length
+     */
+    private int combinedLength(byte[]... arrays) {
+        int combinedLength = 0;
+
+        for (byte[] array : arrays) {
+            combinedLength += array.length;
+        }
+
+        return combinedLength;
+    }
+
+    public byte[] encrypt(byte[] buffer, byte[] salt, byte[] key, String keyid, PublicKey dh, byte[] authSecret, int padSize) throws NoSuchPaddingException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, IllegalBlockSizeException, BadPaddingException, InvalidKeyException, NoSuchProviderException, IOException {
+        byte[][] derivedKey = deriveKey(salt, key, keyid, dh, authSecret, padSize);
+        byte[] key_ = derivedKey[0];
+        byte[] nonce_ = derivedKey[1];
+
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding", "BC");
+        cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key_, "AES"), new GCMParameterSpec(16 * 8, nonce_));
+        cipher.update(new byte[padSize]);
+
+        return cipher.doFinal(buffer);
+    }
+}

--- a/src/main/java/nl/martijndwars/webpush/Notification.java
+++ b/src/main/java/nl/martijndwars/webpush/Notification.java
@@ -1,0 +1,104 @@
+package nl.martijndwars.webpush;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class Notification {
+    /**
+     * The endpoint associated with the push subscription
+     */
+    private final String endpoint;
+
+    /**
+     * The client's public key
+     */
+    private final PublicKey userPublicKey;
+
+    /**
+     * The client's auth
+     */
+    private final byte[] userAuth;
+
+    /**
+     * An arbitrary payload
+     */
+    private final byte[] payload;
+
+    /**
+     * Time in seconds that the push message is retained by the push service
+     */
+    private final int ttl;
+
+    public Notification(String endpoint, PublicKey userPublicKey, byte[] userAuth, byte[] payload, int ttl) {
+        this.endpoint = endpoint;
+        this.userPublicKey = userPublicKey;
+        this.userAuth = userAuth;
+        this.payload = payload;
+        this.ttl = ttl;
+    }
+
+    public Notification(String endpoint, PublicKey userPublicKey, byte[] userAuth, byte[] payload) {
+        this(endpoint, userPublicKey, userAuth, payload, 2419200);
+    }
+
+    public Notification(String endpoint, String userPublicKey, String userAuth, byte[] payload) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidKeySpecException {
+        this(endpoint, Utils.loadPublicKey(userPublicKey), Utils.base64Decode(userAuth), payload);
+    }
+
+    public Notification(String endpoint, String userPublicKey, String userAuth, String payload) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidKeySpecException {
+        this(endpoint, Utils.loadPublicKey(userPublicKey), Utils.base64Decode(userAuth), payload.getBytes(UTF_8));
+    }
+
+    public Notification(Subscription subscription, String payload) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidKeySpecException {
+        this(subscription.endpoint, subscription.keys.p256dh, subscription.keys.auth, payload);
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public PublicKey getUserPublicKey() {
+        return userPublicKey;
+    }
+
+    public byte[] getUserAuth() {
+        return userAuth;
+    }
+
+    public byte[] getPayload() {
+        return payload;
+    }
+
+    public boolean hasPayload() {
+        return getPayload().length > 0;
+    }
+
+    /**
+     * Detect if the notification is for a GCM-based subscription
+     *
+     * @return
+     */
+    public boolean isGcm() {
+        return getEndpoint().indexOf("https://android.googleapis.com/gcm/send") == 0;
+    }
+
+    public int getTTL() {
+        return ttl;
+    }
+
+    public int getPadSize() {
+        return 2;
+    }
+
+    public String getOrigin() throws MalformedURLException {
+        URL url = new URL(getEndpoint());
+
+        return url.getProtocol() + "://" + url.getHost();
+    }
+}

--- a/src/main/java/nl/martijndwars/webpush/PushService.java
+++ b/src/main/java/nl/martijndwars/webpush/PushService.java
@@ -1,0 +1,284 @@
+package nl.martijndwars.webpush;
+
+import com.google.common.io.BaseEncoding;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.impl.nio.client.HttpAsyncClients;
+import org.apache.http.message.BasicHeader;
+import org.bouncycastle.jce.ECNamedCurveTable;
+import org.bouncycastle.jce.interfaces.ECPublicKey;
+import org.bouncycastle.jce.spec.ECNamedCurveParameterSpec;
+import org.jose4j.jws.AlgorithmIdentifiers;
+import org.jose4j.jws.JsonWebSignature;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.lang.JoseException;
+
+import java.io.IOException;
+import java.security.*;
+import java.security.spec.InvalidKeySpecException;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+public class PushService {
+    /**
+     * The Google Cloud Messaging API key (for pre-VAPID in Chrome)
+     */
+    private String gcmApiKey;
+
+    /**
+     * Subject used in the JWT payload (for VAPID)
+     */
+    private String subject;
+
+    /**
+     * The public key (for VAPID)
+     */
+    private PublicKey publicKey;
+
+    /**
+     * The private key (for VAPID)
+     */
+    private Key privateKey;
+
+    public PushService() {
+    }
+
+    public PushService(String gcmApiKey) {
+        this.gcmApiKey = gcmApiKey;
+    }
+
+    public PushService(KeyPair keyPair, String subject) {
+        this.publicKey = keyPair.getPublic();
+        this.privateKey = keyPair.getPrivate();
+        this.subject = subject;
+    }
+
+    public PushService(String publicKey, String privateKey, String subject) throws GeneralSecurityException {
+        this.publicKey = Utils.loadPublicKey(publicKey);
+        this.privateKey = Utils.loadPrivateKey(privateKey);
+        this.subject = subject;
+    }
+
+    /**
+     * Encrypt the getPayload using the user's public key using Elliptic Curve
+     * Diffie Hellman cryptography over the prime256v1 curve.
+     *
+     * @return An Encrypted object containing the public key, salt, and
+     * ciphertext, which can be sent to the other party.
+     */
+    public static Encrypted encrypt(byte[] buffer, PublicKey userPublicKey, byte[] userAuth, int padSize) throws GeneralSecurityException, IOException {
+        ECNamedCurveParameterSpec parameterSpec = ECNamedCurveTable.getParameterSpec("prime256v1");
+
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("ECDH", "BC");
+        keyPairGenerator.initialize(parameterSpec);
+
+        KeyPair serverKey = keyPairGenerator.generateKeyPair();
+
+        Map<String, KeyPair> keys = new HashMap<>();
+        keys.put("server-key-id", serverKey);
+
+        Map<String, String> labels = new HashMap<>();
+        labels.put("server-key-id", "P-256");
+
+        byte[] salt = SecureRandom.getSeed(16);
+
+        HttpEce httpEce = new HttpEce(keys, labels);
+        byte[] ciphertext = httpEce.encrypt(buffer, salt, null, "server-key-id", userPublicKey, userAuth, padSize);
+
+        return new Encrypted.Builder()
+            .withSalt(salt)
+            .withPublicKey(serverKey.getPublic())
+            .withCiphertext(ciphertext)
+            .build();
+    }
+
+    /**
+     * Send a notification and wait for the response.
+     *
+     * @param notification
+     * @return
+     * @throws GeneralSecurityException
+     * @throws IOException
+     * @throws JoseException
+     * @throws ExecutionException
+     * @throws InterruptedException
+     */
+    public HttpResponse send(Notification notification) throws GeneralSecurityException, IOException, JoseException, ExecutionException, InterruptedException {
+        return sendAsync(notification).get();
+    }
+
+    /**
+     * Send a notification, but don't wait for the response.
+     *
+     * @param notification
+     * @return
+     * @throws GeneralSecurityException
+     * @throws IOException
+     * @throws JoseException
+     */
+    public Future<HttpResponse> sendAsync(Notification notification) throws GeneralSecurityException, IOException, JoseException {
+        BaseEncoding base64url = BaseEncoding.base64Url();
+
+        Encrypted encrypted = encrypt(
+            notification.getPayload(),
+            notification.getUserPublicKey(),
+            notification.getUserAuth(),
+            notification.getPadSize()
+        );
+
+        byte[] dh = Utils.savePublicKey((ECPublicKey) encrypted.getPublicKey());
+        byte[] salt = encrypted.getSalt();
+
+        HttpPost httpPost = new HttpPost(notification.getEndpoint());
+        httpPost.addHeader("TTL", String.valueOf(notification.getTTL()));
+
+        Map<String, String> headers = new HashMap<>();
+
+        if (notification.hasPayload()) {
+            headers.put("Content-Type", "application/octet-stream");
+            headers.put("Content-Encoding", "aesgcm");
+            headers.put("Encryption", "keyid=p256dh;salt=" + base64url.omitPadding().encode(salt));
+            headers.put("Crypto-Key", "keyid=p256dh;dh=" + base64url.encode(dh));
+
+            httpPost.setEntity(new ByteArrayEntity(encrypted.getCiphertext()));
+        }
+
+        if (notification.isGcm()) {
+            if (gcmApiKey == null) {
+                throw new IllegalStateException("An GCM API key is needed to send a push notification to a GCM endpoint.");
+            }
+
+            headers.put("Authorization", "key=" + gcmApiKey);
+        }
+
+        if (vapidEnabled() && !notification.isGcm()) {
+            JwtClaims claims = new JwtClaims();
+            claims.setAudience(notification.getOrigin());
+            claims.setExpirationTimeMinutesInTheFuture(12*60);
+            claims.setSubject(subject);
+
+            JsonWebSignature jws = new JsonWebSignature();
+            jws.setHeader("typ", "JWT");
+            jws.setHeader("alg", "ES256");
+            jws.setPayload(claims.toJson());
+            jws.setKey(privateKey);
+            jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.ECDSA_USING_P256_CURVE_AND_SHA256);
+
+            headers.put("Authorization", "WebPush " + jws.getCompactSerialization());
+
+            byte[] pk = Utils.savePublicKey((ECPublicKey) publicKey);
+
+            if (headers.containsKey("Crypto-Key")) {
+                headers.put("Crypto-Key", headers.get("Crypto-Key") + ";p256ecdsa=" + base64url.omitPadding().encode(pk));
+            } else {
+                headers.put("Crypto-Key", "p256ecdsa=" + base64url.encode(pk));
+            }
+        }
+
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            httpPost.addHeader(new BasicHeader(entry.getKey(), entry.getValue()));
+        }
+
+        final CloseableHttpAsyncClient closeableHttpAsyncClient = HttpAsyncClients.createSystem();
+        closeableHttpAsyncClient.start();
+
+        return closeableHttpAsyncClient.execute(httpPost, new ClosableCallback(closeableHttpAsyncClient));
+    }
+
+    /**
+     * Set the Google Cloud Messaging (GCM) API key
+     *
+     * @param gcmApiKey
+     * @return
+     */
+    public PushService setGcmApiKey(String gcmApiKey) {
+        this.gcmApiKey = gcmApiKey;
+
+        return this;
+    }
+
+    /**
+     * Set the JWT subject (for VAPID)
+     *
+     * @param subject
+     * @return
+     */
+    public PushService setSubject(String subject) {
+        this.subject = subject;
+
+        return this;
+    }
+
+    /**
+     * Set the public and private key (for VAPID).
+     *
+     * @param keyPair
+     * @return
+     */
+    public PushService setKeyPair(KeyPair keyPair) {
+        setPublicKey(keyPair.getPublic());
+        setPrivateKey(keyPair.getPrivate());
+
+        return this;
+    }
+
+    /**
+     * Set the public key using a base64url-encoded string.
+     *
+     * @param publicKey
+     * @return
+     */
+    public PushService setPublicKey(String publicKey) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidKeySpecException {
+        setPublicKey(Utils.loadPublicKey(publicKey));
+
+        return this;
+    }
+
+    /**
+     * Set the public key (for VAPID)
+     *
+     * @param publicKey
+     * @return
+     */
+    public PushService setPublicKey(PublicKey publicKey) {
+        this.publicKey = publicKey;
+
+        return this;
+    }
+
+    /**
+     * Set the public key using a base64url-encoded string.
+     *
+     * @param privateKey
+     * @return
+     */
+    public PushService setPrivateKey(String privateKey) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidKeySpecException {
+        setPrivateKey(Utils.loadPrivateKey(privateKey));
+
+        return this;
+    }
+
+    /**
+     * Set the private key (for VAPID)
+     *
+     * @param privateKey
+     * @return
+     */
+    public PushService setPrivateKey(PrivateKey privateKey) {
+        this.privateKey = privateKey;
+
+        return this;
+    }
+
+    /**
+     * Check if VAPID is enabled
+     *
+     * @return
+     */
+    protected boolean vapidEnabled() {
+        return publicKey != null && privateKey != null;
+    }
+}

--- a/src/main/java/nl/martijndwars/webpush/Secret.java
+++ b/src/main/java/nl/martijndwars/webpush/Secret.java
@@ -1,0 +1,16 @@
+package nl.martijndwars.webpush;
+
+public class Secret {
+    public String privateKey;
+    public String publicKey;
+    public Subscription subscription;
+
+    public Secret() { }
+
+    public Secret(String privateKey, String publicKey, Subscription subscription) {
+        this.privateKey = privateKey;
+        this.publicKey = publicKey;
+        this.subscription = subscription;
+    }
+
+}

--- a/src/main/java/nl/martijndwars/webpush/Stanza.java
+++ b/src/main/java/nl/martijndwars/webpush/Stanza.java
@@ -1,0 +1,15 @@
+package nl.martijndwars.webpush;
+
+public class Stanza {
+    public String msgType;
+    public String msgFrom;
+    public String msgBody;
+
+    public Stanza() { }
+
+    public Stanza(String msgType, String msgFrom, String msgBody) {
+        this.msgFrom = msgFrom;
+        this.msgFrom = msgFrom;
+        this.msgBody = msgBody;
+    }
+}

--- a/src/main/java/nl/martijndwars/webpush/Subscription.java
+++ b/src/main/java/nl/martijndwars/webpush/Subscription.java
@@ -1,0 +1,31 @@
+package nl.martijndwars.webpush;
+
+public class Subscription {
+    public String endpoint;
+
+    public Keys keys;
+
+    public Subscription() {
+        // No-args constructor
+    }
+
+    public Subscription(String endpoint, Keys keys) {
+        this.endpoint = endpoint;
+        this.keys = keys;
+    }
+
+    public class Keys {
+        public String p256dh;
+
+        public String auth;
+
+        public Keys() {
+            // No-args constructor
+        }
+
+        public Keys(String p256dh, String auth) {
+            this.p256dh = p256dh;
+            this.auth = auth;
+        }
+    }
+}

--- a/src/main/java/nl/martijndwars/webpush/Utils.java
+++ b/src/main/java/nl/martijndwars/webpush/Utils.java
@@ -1,0 +1,88 @@
+package nl.martijndwars.webpush;
+
+import com.google.common.io.BaseEncoding;
+import org.bouncycastle.jce.ECNamedCurveTable;
+import org.bouncycastle.jce.interfaces.ECPrivateKey;
+import org.bouncycastle.jce.interfaces.ECPublicKey;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.jce.spec.ECNamedCurveParameterSpec;
+import org.bouncycastle.jce.spec.ECParameterSpec;
+import org.bouncycastle.jce.spec.ECPrivateKeySpec;
+import org.bouncycastle.jce.spec.ECPublicKeySpec;
+import org.bouncycastle.math.ec.ECPoint;
+
+import java.math.BigInteger;
+import java.security.*;
+import java.security.spec.InvalidKeySpecException;
+
+public class Utils {
+    /**
+     * Get the uncompressed encoding of the public key point. The resulting array
+     * should be 65 bytes length and start with 0x04 followed by the x and y
+     * coordinates (32 bytes each).
+     *
+     * @param publicKey
+     * @return
+     */
+    public static byte[] savePublicKey(ECPublicKey publicKey) {
+        return publicKey.getQ().getEncoded(false);
+    }
+
+    public static byte[] savePrivateKey(ECPrivateKey privateKey) {
+        return privateKey.getD().toByteArray();
+    }
+
+    /**
+     * Base64-decode a string. Works for both url-safe and non-url-safe
+     * encodings.
+     *
+     * @param base64Encoded
+     * @return
+     */
+    public static byte[] base64Decode(String base64Encoded) {
+        if (base64Encoded.contains("+") || base64Encoded.contains("/")) {
+            return BaseEncoding.base64().decode(base64Encoded);
+        } else {
+            return BaseEncoding.base64Url().decode(base64Encoded);
+        }
+    }
+
+    /**
+     * Load the public key from a URL-safe base64 encoded string. Takes into
+     * account the different encodings, including point compression.
+     *
+     * @param encodedPublicKey
+     */
+    public static PublicKey loadPublicKey(String encodedPublicKey) throws NoSuchProviderException, NoSuchAlgorithmException, InvalidKeySpecException {
+        byte[] decodedPublicKey = base64Decode(encodedPublicKey);
+
+        KeyFactory kf = KeyFactory.getInstance("ECDH", BouncyCastleProvider.PROVIDER_NAME);
+
+        // prime256v1 is NIST P-256
+        ECNamedCurveParameterSpec ecSpec = ECNamedCurveTable.getParameterSpec("prime256v1");
+        ECPoint point = ecSpec.getCurve().decodePoint(decodedPublicKey);
+        ECPublicKeySpec pubSpec = new ECPublicKeySpec(point, ecSpec);
+
+        return kf.generatePublic(pubSpec);
+    }
+
+    /**
+     * Load the private key from a URL-safe base64 encoded string
+     *
+     * @param encodedPrivateKey
+     * @return
+     * @throws NoSuchProviderException
+     * @throws NoSuchAlgorithmException
+     * @throws InvalidKeySpecException
+     */
+    public static PrivateKey loadPrivateKey(String encodedPrivateKey) throws NoSuchProviderException, NoSuchAlgorithmException, InvalidKeySpecException {
+        byte[] decodedPrivateKey = base64Decode(encodedPrivateKey);
+
+        // prime256v1 is NIST P-256
+        ECParameterSpec params = ECNamedCurveTable.getParameterSpec("prime256v1");
+        ECPrivateKeySpec prvkey = new ECPrivateKeySpec(new BigInteger(decodedPrivateKey), params);
+        KeyFactory kf = KeyFactory.getInstance("ECDH", BouncyCastleProvider.PROVIDER_NAME);
+
+        return kf.generatePrivate(prvkey);
+    }
+}


### PR DESCRIPTION
This is currently running and being tested at wikisuite.chat.  The changes I made can be summarized as follows

1. Check the domain of the push app server. If it matches the XMPP server, dont send an IQ to the push app component. Instead, handle internally and assume it is a web-push. Use the [web push library](https://github.com/web-push-libs/webpush-java) to encrypt, encode and send the HTTP post to the embedded URL in the push-options base64 encoded JSON string called *secret*

2. Use the PresenceManager to confirm user is NOT available before pushing a notification. Web Push browser vendors have quota for each subscriber and sending every <message> stanza will exceed it.