### PR TITLE
Release 0.7.0 (and a fix)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>pushnotification</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0-SNAPSHOT</version>
 
     <name>Push Notification</name>
     <description>Adds Push Notification (XEP-0357) support to Openfire.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>pushnotification</artifactId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>0.7.0</version>
 
     <name>Push Notification</name>
     <description>Adds Push Notification (XEP-0357) support to Openfire.</description>

--- a/src/changelog.html
+++ b/src/changelog.html
@@ -44,7 +44,7 @@
 Push Notification Plugin Changelog
 </h1>
 
-<p><b>0.7.0</b> -- (tbd)</p>
+<p><b>0.7.0</b> -- April 26, 2020</p>
 <ul>
     <li><a href="https://github.com/igniterealtime/openfire-pushnotification-plugin/issues/6">Issue #6</a>: Add content to push notifications that allow them to wake up an IOS app</li>
     <li><a href="https://github.com/igniterealtime/openfire-pushnotification-plugin/issues/7">Issue #7</a>: Rate-limit the amount of push notifications being sent per user</li>

--- a/src/plugin.xml
+++ b/src/plugin.xml
@@ -7,7 +7,7 @@
     <version>${project.version}</version>
 
     <author>Guus der Kinderen</author>
-    <date>04/23/2020</date>
+    <date>04/26/2020</date>
 
     <minJavaVersion>1.8</minJavaVersion>
 


### PR DESCRIPTION
Don't squash this PR, as we need to set a release tag on the commit marked to 'denote release'.