### PR TITLE
fixes #19: Prevent ClassCastExceptions after reloading/updating the plugin

### DIFF
--- a/src/changelog.html
+++ b/src/changelog.html
@@ -47,6 +47,7 @@ Push Notification Plugin Changelog
 <p><b>0.8.0</b> -- (tbd)</p>
 <ul>
     <li><a href="https://github.com/igniterealtime/openfire-pushnotification-plugin/issues/15">Issue #15</a>: Define minimum server requirement (4.3.0).</li>
+    <li><a href="https://github.com/igniterealtime/openfire-pushnotification-plugin/issues/19">Issue #19</a>: Prevent ClassCastExceptions after reloading/updating the plugin.</li>
 </ul>
 
 <p><b>0.7.0</b> -- April 26, 2020</p>


### PR DESCRIPTION
This commit replaces the usage of classes provided by the plugin itself during cache usage. ClassCastExceptions
can occur when a cache has a reference to a class that was loaded by a PluginClassLoader from a previous incarnation
of this plugin.

See #19 for more details.