### PR TITLE
Fix compatibility issue with Openfire 4.9.0

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -46,6 +46,7 @@ Push Notification Plugin Changelog
 
 <p><b>1.0.1</b> -- To Be Determined</p>
 <ul>
+    <li><a href="https://github.com/igniterealtime/openfire-pushnotification-plugin/issues/41">Issue 41</a>: Replaced all usage of code removed or deprecated in Openfire 4.9.0</li>
 </ul>
 
 <p><b>1.0.0</b> -- November 27, 2023</p>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.7.5</version>
+        <version>4.8.0</version>
     </parent>
 
     <groupId>org.igniterealtime.openfire.plugins</groupId>

--- a/src/main/java/org/igniterealtime/openfire/plugins/pushnotification/PushInterceptor.java
+++ b/src/main/java/org/igniterealtime/openfire/plugins/pushnotification/PushInterceptor.java
@@ -265,7 +265,7 @@ public class PushInterceptor implements PacketInterceptor, OfflineMessageListene
                 try
                 {
                     Log.trace( "For user '{}', Routing push notification to '{}'", user.toString(), push.getTo() );
-                    XMPPServer.getInstance().getRoutingTable().routePacket( push.getTo(), push, true );
+                    XMPPServer.getInstance().getRoutingTable().routePacket( push.getTo(), push );
                 } catch ( Exception e ) {
                     Log.warn( "An exception occurred while trying to deliver a notification for user '{}' to node '{}' on service '{}'.", new Object[] { user, node, service, e } );
                 }

--- a/src/plugin.xml
+++ b/src/plugin.xml
@@ -7,7 +7,7 @@
     <version>${project.version}</version>
 
     <author>Guus der Kinderen</author>
-    <date>2023-11-27</date>
+    <date>2024-08-23</date>
 
     <minServerVersion>4.8.0</minServerVersion>
 


### PR DESCRIPTION
Replaced Openfire API usage that was deprecated in Openfire 4.8.0 and removed in 4.9.0, with API that was introduced in 4.8.0

This plugin is continues to be compatible with Openfire 4.8.0.

fixes #41