### PR TITLE
OF-3033: Postpone SM termination without push notifications

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -44,8 +44,10 @@
 Push Notification Plugin Changelog
 </h1>
 
-<p><b>1.0.2</b> -- (To be determined)</p>
+<p><b>1.1.0</b> -- (To be determined)</p>
 <ul>
+    <li>New minimum server requirement: 5.0.0</li>
+    <li><a href="https://igniterealtime.atlassian.net/browse/OF-3033">Issue OF-3033</a>: Integrate with Stream Management to optimize UX in apps that can't keep a socket connection open.</li>
 </ul>
 
 <p><b>1.0.1</b> -- September 12, 2024</p>

--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.8.0</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>pushnotification</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <name>Push Notification</name>
     <description>Adds Push Notification (XEP-0357) support to Openfire.</description>

--- a/src/main/java/org/igniterealtime/openfire/plugins/pushnotification/Push0IQHandler.java
+++ b/src/main/java/org/igniterealtime/openfire/plugins/pushnotification/Push0IQHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.igniterealtime.openfire.plugins.pushnotification;
 import org.dom4j.Element;
 import org.dom4j.QName;
 import org.dom4j.util.NodeComparator;
+import org.igniterealtime.openfire.plugins.pushnotification.streammanagement.TerminationDelegateManager;
 import org.jivesoftware.openfire.IQHandlerInfo;
 import org.jivesoftware.openfire.XMPPServer;
 import org.jivesoftware.openfire.auth.UnauthorizedException;
@@ -147,6 +148,7 @@ public class Push0IQHandler extends IQHandler implements UserFeaturesProvider
                     else
                     {
                         PushServiceManager.register( user, pushService, node, publishOptions );
+                        TerminationDelegateManager.registerDelegateFor(user);
                         Log.debug( "Registered push service '{}', node '{}', for user '{}'.", new Object[]{ pushService.toString(), node, user.getUsername() } );
                     }
                     response = IQ.createResultIQ( packet );
@@ -163,6 +165,9 @@ public class Push0IQHandler extends IQHandler implements UserFeaturesProvider
                 try
                 {
                     PushServiceManager.deregister( user, pushService, node );
+                    if (!PushServiceManager.hasServiceNodes(user)) {
+                        TerminationDelegateManager.deregisterDelegateFor(user);
+                    }
                     Log.debug( "Deregistered push service '{}', node '{}', for user '{}'.", new Object[]{ pushService.toString(), node, user.getUsername() } );
                     response = IQ.createResultIQ( packet );
                 }

--- a/src/main/java/org/igniterealtime/openfire/plugins/pushnotification/PushInterceptor.java
+++ b/src/main/java/org/igniterealtime/openfire/plugins/pushnotification/PushInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.igniterealtime.openfire.plugins.pushnotification;
 
 import org.dom4j.Element;
 import org.dom4j.QName;
+import org.igniterealtime.openfire.plugins.pushnotification.streammanagement.TerminationDelegateManager;
 import org.jivesoftware.openfire.OfflineMessage;
 import org.jivesoftware.openfire.OfflineMessageListener;
 import org.jivesoftware.openfire.XMPPServer;
@@ -266,6 +267,7 @@ public class PushInterceptor implements PacketInterceptor, OfflineMessageListene
                 {
                     Log.trace( "For user '{}', Routing push notification to '{}'", user.toString(), push.getTo() );
                     XMPPServer.getInstance().getRoutingTable().routePacket( push.getTo(), push );
+                    TerminationDelegateManager.registerPushNotificationFor(user);
                 } catch ( Exception e ) {
                     Log.warn( "An exception occurred while trying to deliver a notification for user '{}' to node '{}' on service '{}'.", new Object[] { user, node, service, e } );
                 }

--- a/src/main/java/org/igniterealtime/openfire/plugins/pushnotification/PushServiceManager.java
+++ b/src/main/java/org/igniterealtime/openfire/plugins/pushnotification/PushServiceManager.java
@@ -183,4 +183,9 @@ public class PushServiceManager
         Log.trace( "User '{}' has {} push notification services configured.", user, result.size());
         return result;
     }
+
+    public static boolean hasServiceNodes( final User user ) throws SQLException
+    {
+        return !getServiceNodes(user).isEmpty();
+    }
 }

--- a/src/main/java/org/igniterealtime/openfire/plugins/pushnotification/streammanagement/PushNotificationSteamManagementTerminationDelegate.java
+++ b/src/main/java/org/igniterealtime/openfire/plugins/pushnotification/streammanagement/PushNotificationSteamManagementTerminationDelegate.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2025 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.igniterealtime.openfire.plugins.pushnotification.streammanagement;
+
+import org.jivesoftware.openfire.streammanagement.TerminationDelegate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Determines if a detached session (in context of Stream Management) can be terminated based on push notifications.
+ *
+ * For a user that has push notifications enabled, a session is allowed to be terminated only after a first push
+ * notification has been sent. The rationale for this is that some clients (notably IOS-based clients) are not able to
+ * maintain a connection to the server while running in the background (which can happen as often as every 30 seconds).
+ * To terminate such clients would lead to a considerable amount of session lifecycles. This implementation considers
+ * that such clients would react almost instantly to a push notification. Thus, SM termination is appropriate when a
+ * client remains inactive after it was sent the first push notification.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ */
+public class PushNotificationSteamManagementTerminationDelegate implements TerminationDelegate
+{
+    private static final Logger Log = LoggerFactory.getLogger(PushNotificationSteamManagementTerminationDelegate.class);
+
+    private Instant oldestUnansweredPushNotification;
+
+    @Override
+    public synchronized boolean shouldTerminate(@Nonnull final Duration allowableInactivity)
+    {
+        final boolean result = oldestUnansweredPushNotification != null && oldestUnansweredPushNotification.isBefore(Instant.now().minus(allowableInactivity));
+        Log.trace("Should terminate: {} (Oldest unanswered notification: {} - Allowable inactivity: {})", (result ? "yes" : "no"), oldestUnansweredPushNotification, allowableInactivity);
+        return result;
+    }
+
+    public synchronized void registerActivity() {
+        oldestUnansweredPushNotification = null;
+    }
+
+    public synchronized void registerPushNotification() {
+        if (oldestUnansweredPushNotification == null) {
+            oldestUnansweredPushNotification = Instant.now();
+        }
+    }
+}

--- a/src/main/java/org/igniterealtime/openfire/plugins/pushnotification/streammanagement/TerminationDelegateManager.java
+++ b/src/main/java/org/igniterealtime/openfire/plugins/pushnotification/streammanagement/TerminationDelegateManager.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (C) 2025 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.igniterealtime.openfire.plugins.pushnotification.streammanagement;
+
+import org.igniterealtime.openfire.plugins.pushnotification.PushServiceManager;
+import org.jivesoftware.openfire.SessionManager;
+import org.jivesoftware.openfire.event.SessionEventListener;
+import org.jivesoftware.openfire.interceptor.PacketInterceptor;
+import org.jivesoftware.openfire.interceptor.PacketRejectedException;
+import org.jivesoftware.openfire.session.ClientSession;
+import org.jivesoftware.openfire.session.LocalClientSession;
+import org.jivesoftware.openfire.session.Session;
+import org.jivesoftware.openfire.user.User;
+import org.jivesoftware.openfire.user.UserManager;
+import org.jivesoftware.openfire.user.UserNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xmpp.packet.Packet;
+
+import javax.annotation.Nonnull;
+import java.sql.SQLException;
+
+/**
+ * Responsible for managing instances of {@link PushNotificationSteamManagementTerminationDelegate} on all applicable
+ * client sessions.
+ *
+ * Instances are stored as a sessionData on the session object itself, using the key defined by {@link #PUSHNOTIFICATION_TERMINATION_DELEGATE}
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ */
+public class TerminationDelegateManager implements SessionEventListener, PacketInterceptor
+{
+    private static final Logger Log = LoggerFactory.getLogger(TerminationDelegateManager.class);
+
+    public static final String PUSHNOTIFICATION_TERMINATION_DELEGATE = "pushnotification.terminationDelegate";
+
+    @Override
+    public void sessionCreated(Session session)
+    {
+        if (!(session instanceof LocalClientSession)) {
+            return;
+        }
+        final LocalClientSession clientSession = (LocalClientSession) session;
+
+        // If the user has push notification enabled, register the delegate.
+        final boolean hasPushEnabled = doesUserHavePushEnabled(clientSession);
+        if (hasPushEnabled) {
+            registerDelegate(clientSession);
+        }
+    }
+
+    @Override
+    public void sessionDestroyed(Session session)
+    {
+        if (!(session instanceof LocalClientSession)) {
+            return;
+        }
+
+        // Remove a delegate (if one was active).
+        deregisterDelegate((LocalClientSession) session);
+    }
+
+    public static void registerDelegate(final LocalClientSession clientSession) {
+        if (clientSession.getSessionData(PUSHNOTIFICATION_TERMINATION_DELEGATE) == null) {
+            Log.trace("Registering delegate for {}", clientSession);
+            final PushNotificationSteamManagementTerminationDelegate delegate = new PushNotificationSteamManagementTerminationDelegate();
+            clientSession.setSessionData(PUSHNOTIFICATION_TERMINATION_DELEGATE, delegate);
+            clientSession.getStreamManager().addTerminationDelegate(delegate);
+        } else {
+            Log.trace("Skip registering delegate (one already is registered) for {}", clientSession);
+        }
+    }
+
+    public static void deregisterDelegate(final LocalClientSession clientSession) {
+        final PushNotificationSteamManagementTerminationDelegate delegate = (PushNotificationSteamManagementTerminationDelegate) clientSession.removeSessionData(PUSHNOTIFICATION_TERMINATION_DELEGATE);
+        if (delegate != null) {
+            Log.trace("Deregistering delegate for {}", clientSession);
+            clientSession.getStreamManager().removeTerminationDelegate(delegate);
+        }
+    }
+
+    public static void registerDelegateFor(@Nonnull final User user) {
+        Log.trace("Registering delegate for all sessions of {}", user);
+        SessionManager.getInstance().getSessions(user.getUsername()).stream()
+            .filter(session -> session instanceof LocalClientSession)
+            .map(session -> (LocalClientSession) session)
+            .forEach(TerminationDelegateManager::registerDelegate);
+    }
+
+    public static void deregisterDelegateFor(@Nonnull final User user) {
+        Log.trace("Deregistering delegate for all sessions of {}", user);
+        SessionManager.getInstance().getSessions(user.getUsername()).stream()
+            .filter(session -> session instanceof LocalClientSession)
+            .map(session -> (LocalClientSession) session)
+            .forEach(TerminationDelegateManager::deregisterDelegate);
+    }
+
+    public static void registerDelegateForAll() {
+        Log.debug("Registering delegate for all sessions...");
+        SessionManager.getInstance().getSessions().stream()
+            .filter(session -> session instanceof LocalClientSession)
+            .map(session -> (LocalClientSession) session)
+            .forEach(session -> {
+                final boolean hasPushEnabled = doesUserHavePushEnabled(session);
+                if (hasPushEnabled) {
+                    registerDelegate(session);
+                }
+            });
+        Log.debug("Done registering delegate for all sessions.");
+    }
+
+    public static void deregisterDelegateForAll() {
+        Log.debug("Deregistering delegate for all sessions...");
+        SessionManager.getInstance().getSessions().stream()
+            .filter(session -> session instanceof LocalClientSession)
+            .map(session -> (LocalClientSession) session)
+            .forEach(TerminationDelegateManager::deregisterDelegate);
+        Log.debug("Done deregistering delegate for all sessions.");
+    }
+
+    public static void registerActivityFor(@Nonnull final LocalClientSession clientSession) {
+        final PushNotificationSteamManagementTerminationDelegate delegate = (PushNotificationSteamManagementTerminationDelegate) clientSession.getSessionData(PUSHNOTIFICATION_TERMINATION_DELEGATE);
+        if (delegate != null) {
+            delegate.registerActivity();
+        }
+    }
+
+    public static void registerPushNotificationFor(@Nonnull final User user) {
+        SessionManager.getInstance().getSessions(user.getUsername()).stream()
+            .filter(session -> session instanceof LocalClientSession)
+            .map(session -> (LocalClientSession) session)
+            .forEach(session -> {
+                final PushNotificationSteamManagementTerminationDelegate delegate = (PushNotificationSteamManagementTerminationDelegate) session.getSessionData(PUSHNOTIFICATION_TERMINATION_DELEGATE);
+                if (delegate != null) {
+                    delegate.registerPushNotification();
+                }
+            });
+    }
+
+    public static boolean doesUserHavePushEnabled(final User user) {
+        try {
+            return PushServiceManager.hasServiceNodes(user);
+        } catch (SQLException e) {
+            Log.warn("A database problem prevented a check to see if user {} has push notifications enabled.", user, e);
+        }
+        return false;
+    }
+
+    public static boolean doesUserHavePushEnabled(final ClientSession clientSession) {
+        try {
+            final String username = clientSession.getUsername();
+            final User user = UserManager.getInstance().getUser(username);
+            return PushServiceManager.hasServiceNodes(user);
+        } catch (UserNotFoundException e) {
+            Log.warn("Unable to perform a check to see if the user related to this session has push notifications enabled: {}", clientSession, e);
+        } catch (SQLException e) {
+            Log.warn("A database problem prevented a check to see if the user related to this session has push notifications enabled: {}", clientSession, e);
+        }
+        return false;
+    }
+
+    @Override
+    public void interceptPacket(final Packet packet, final Session session, final boolean incoming, final boolean processed) throws PacketRejectedException
+    {
+        if (!(session instanceof LocalClientSession)) {
+            return;
+        }
+
+        final boolean inbound = incoming && !processed; // pre or post processed probably doesn't matter, but we don't want to fire twice.
+        if (!inbound) {
+            return;
+        }
+
+        registerActivityFor((LocalClientSession) session);
+    }
+
+    @Override
+    public void anonymousSessionCreated(Session session) {}
+
+    @Override
+    public void anonymousSessionDestroyed(Session session) {}
+
+    @Override
+    public void resourceBound(Session session) {}
+}

--- a/src/plugin.xml
+++ b/src/plugin.xml
@@ -7,9 +7,9 @@
     <version>${project.version}</version>
 
     <author>Guus der Kinderen</author>
-    <date>2024-09-12</date>
+    <date>2025-03-05</date>
 
-    <minServerVersion>4.8.0</minServerVersion>
+    <minServerVersion>5.0.0</minServerVersion>
 
     <databaseKey>pushnotification</databaseKey>
     <databaseVersion>1</databaseVersion>


### PR DESCRIPTION
For a user that has push notifications enabled, a session that is detached (in context of Stream Management) is allowed to be terminated only after a first push notification has been sent.

The rationale for this is that some clients (notably IOS-based clients) are not able to maintain a connection to the server while running in the background (which can happen as often as every 30 seconds). To terminate such clients would lead to a considerable amount of session lifecycles. This implementation considers that such clients would react almost instantly to a push notification. Thus, SM termination is appropriate when a client remains inactive after it was sent the first push notification.

This commit depends on [a corresponding change](https://github.com/igniterealtime/Openfire/pull/2709) in Openfire.